### PR TITLE
Use prop-types instead of React.PropTypes

### DIFF
--- a/libs/CardView.android.js
+++ b/libs/CardView.android.js
@@ -1,4 +1,4 @@
-import { PropTypes } from 'react';
+import { PropTypes } from 'prop-types';
 import { requireNativeComponent, View } from 'react-native';
 var iface = {
   name: 'CardView',

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "homepage": "https://github.com/Kishanjvaghela/react-native-card-view",
   "devDependencies": {
+    "prop-types": "^15.6.0",
     "react-native": "^0.41.2"
   }
 }


### PR DESCRIPTION
because React.PropTypes in react@16.0.0 has been removed from the core package. Facebook recommend use prop-types library instead React.PropTypes