### PR TITLE
fixes gradle build (RN 0.58+) for android

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,17 +2,21 @@
 buildscript {
     repositories {
         jcenter()
+        maven {
+          url 'https://maven.google.com/'
+          name 'Google'
+        }
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
     }
 }
 
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 27
+    compileSdkVersion 28
     buildToolsVersion "27.0.3"
 
     defaultConfig {


### PR DESCRIPTION
Could not build with RN 0.58.4 on Android. This PR Fixed it:

Changes:
- added maven repository 
- bumped gradle to "3.0.0"
