### PR TITLE
added mavenCentral() for gradle builds

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,6 +1,7 @@
 
 buildscript {
     repositories {
+        mavenCentral()
         jcenter()
         maven {
           url 'https://maven.google.com/'


### PR DESCRIPTION
As jCenter is shutting down so adding mavenCentral() so that gradle builds fail